### PR TITLE
Add optional clusterName to splunk-kubernetes-objects

### DIFF
--- a/helm-chart/splunk-kubernetes-objects/examples/full.yaml
+++ b/helm-chart/splunk-kubernetes-objects/examples/full.yaml
@@ -1,3 +1,5 @@
+clusterName: "MY_CLUSTER"
+
 logLevel: error
 
 rbac:

--- a/helm-chart/splunk-kubernetes-objects/templates/configMap.yaml
+++ b/helm-chart/splunk-kubernetes-objects/templates/configMap.yaml
@@ -82,6 +82,13 @@ data:
       jq '.record.source = "namespace:\(env.MY_NAMESPACE)/pod:\(env.MY_POD_NAME)" | .record.sourcetype = (.tag | gsub("\\\\."; ":")) | .record'
     </filter>
 
+    {{- if .Values.clusterName }}
+    <filter kube.**>
+      @type jq_transformer
+      jq '.record.cluster_name = {{ quote .Values.clusterName }} | .record'
+    </filter>
+    {{- end }}
+
     <match kube.**>
       @type splunk_hec
       protocol {{ or .Values.splunk.hec.protocol .Values.global.splunk.hec.protocol | default "https" }}

--- a/helm-chart/splunk-kubernetes-objects/values.yaml
+++ b/helm-chart/splunk-kubernetes-objects/values.yaml
@@ -17,6 +17,10 @@ global:
       insecureSSL: false
 
 
+# If clusterName is set, a cluster_name field will be added to the log output
+clusterName:
+
+
 # = Log Level =
 # logLevel is to set log level of the object collector. Avaiable values are:
 # * trace


### PR DESCRIPTION
This adds a configurable clusterName to all objects logged through splunk-kubernetes-objects.

Once it's been added to metrics as well, this config should probably be
moved to a global value.

This has been deployed on manual-cluster-v0, and seems to be working correctly.